### PR TITLE
Patch 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jecoin",
-  "version": "0.10.0",
-  "description": "Node for JeChain - an educational-purpose smart-contract-supported blockchain network",
+  "name": "jechain",
+  "version": "0.11.0",
+  "description": "Node for JeChain - an experimental smart contract blockchain network",
   "main": "./src/jenode.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src/blockchain.js
+++ b/src/blockchain.js
@@ -13,7 +13,7 @@ class Blockchain {
         // Transaction pool
         this.transactions = [];
         // Blocks
-        this.chain = [new Block(1, "", [initialCoinRelease], 1)];
+        this.chain = [new Block(1, "1647245268695", [initialCoinRelease], 1)];
         // Mining difficulty
         this.difficulty = 1;
         // Fixed blockTime

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,5 @@
+function log16(x) {
+    return Math.log(x) / Math.log(16);
+}
+
+module.exports = { log16 };

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,6 +1,7 @@
 // Worker thread's code.
 
 const Block = require("./block");
+const { log16 } = require("./utils");
 
 // Listening for messages from the main process.
 process.on("message", message => {
@@ -12,7 +13,7 @@ process.on("message", message => {
 
         for (;;) {
             // We will loop until the hash has "4+difficulty" starting zeros.
-            if (block.hash.startsWith("0000" + Array(difficulty + 1).join("0"))) {
+            if (block.hash.startsWith("0000" + Array(Math.floor(log16(difficulty)) + 1).join("0"))) {
                 process.send({ result: block });
 
                 break;


### PR DESCRIPTION
Fix difficulty adjustment:
- Difficulty is adjusted when every 100 blocks are mined.
- Removed the ability to tell others difficulty through block suggestion.
- Mining time is determined by block timestamps ( (n+100)th block's timestamp - (n)th block's timestamp).
- Changed difficulty adjustment formula, the new difficulty will now be calculated with `old difficulty * 3000000 / mining time`.
- New proof requirement: `4+log16(difficulty)`.